### PR TITLE
Refactor covariance matrix calculations:

### DIFF
--- a/example_deep.py
+++ b/example_deep.py
@@ -11,10 +11,10 @@ from torch.autograd import Variable
 from tqdm import tqdm, trange
 
 transform = transforms.Compose(
-    [transforms.ToTensor(), transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))]
+    [transforms.ToTensor(), transforms.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225))]
 )
 
-batch_size = 128
+batch_size = 64
 
 train_set = torchvision.datasets.CIFAR10(
     root='./data', train=True, download=True, transform=transform
@@ -55,13 +55,13 @@ torch.manual_seed(1)
 cuda = torch.cuda.is_available()
 epochs = 5
 
-for h2 in [8, 32, 128]:  # compare various hidden layer sizes
+for h2 in [8, 12, 16, 32]:  # compare various hidden layer sizes
     net = Net(h2=h2)  # instantiate network with hidden layer size `h2`
 
     if cuda:
         net.cuda()
     criterion = nn.CrossEntropyLoss()
-    optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
+    optimizer = optim.SGD(net.parameters(), lr=0.005, momentum=0.9, nesterov=True)
 
     logging_dir = 'convNet/h2-{}'.format(h2)
     stats = CheckLayerSat(logging_dir, net)


### PR DESCRIPTION
Refactor covariance matrix calculations:
- use only the most current activation
- change default sampling rate from B
- flatten B, H, W for Conv layers instead of median

Fix calculation of number of eigval by argmax.

Change CIFAR10 training schedule for faster convergence (the loss seemed not to drop almost at all during training example_deep.py):
- normalization function
- batch size
- learning rate
- h2 sizes (due to different saturation calculations)